### PR TITLE
Fix test suite and add stub service

### DIFF
--- a/backend/varta_service.py
+++ b/backend/varta_service.py
@@ -1,0 +1,2 @@
+async def varta_lookup(sporring: str):
+    return f"Dummy response for {sporring}"

--- a/test_openai.py
+++ b/test_openai.py
@@ -1,3 +1,13 @@
+"""Simple script for manual OpenAI API check.
+
+This file is not intended to be collected by pytest during the automated test
+suite.  The ``__test__`` flag prevents pytest from treating this module as a
+test.  Run the script manually if you want to verify connectivity to the
+OpenAI service.
+"""
+
+__test__ = False
+
 import os
 from dotenv import load_dotenv
 from openai import AsyncOpenAI

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,15 +6,15 @@ client = TestClient(app)
 
 
 def test_ping():
-    response = client.get("/ping")
+    response = client.get("/api/ping")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
 
 def test_chat_missing_message():
     response = client.post("/api/chat", json={})
-    assert response.status_code == 400 or 422  # Juster ift valgte feilstatus
-    assert "error" in response.json()
+    assert response.status_code == 422
+    assert "detail" in response.json()
 
 
 def test_chat_valid_message():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from main import app
+from backend.main import app
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- fix failing API tests by using correct endpoints and adjusting message validation
- ensure `test_main` imports backend entrypoint
- add stub `varta_service` so imports succeed
- prevent `test_openai.py` from being collected as a test

## Testing
- `OPENAI_API_KEY=dummy pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889609ca91c832bb0497927b821ab18